### PR TITLE
Add expire_days property to buckets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,12 @@ RUN mc --version
 WORKDIR /ansible
 
 # Copy Ansible files
-COPY inventory.ini ansible.cfg ./
+COPY ansible.cfg ./
 COPY roles ./roles
 COPY playbooks ./playbooks
+
+# This directory should be mounted by the user
+COPY tests/inventory.ini /config/inventory.ini
 
 # Run playbook
 ENTRYPOINT ["ansible-playbook", "playbooks/main.yml"]

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,11 +7,10 @@ remote_tmp = /tmp/ansible
 local_tmp = /tmp/ansible
 
 # Core ansible files (built into image)
-inventory = /ansible/inventory
 roles_path = /ansible/roles
 collections_path = /ansible/collections
 
 # User-provided files (mounted at runtime)
-# inventory = /config/inventory
-host_vars_path = /config/host_vars
-group_vars_path = /config/group_vars
+inventory = /config/inventory.ini
+# host_vars_path = /config/host_vars
+# group_vars_path = /config/group_vars

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -49,7 +49,7 @@ services:
         set -ex
         ansible-playbook playbooks/main.yml
         for config in $(ls /config/extra_vars/*.yml); do
-          ansible-playbook playbooks/main.yml --extra-vars "@$${config}" --inventory /config/inventory.ini
+          ansible-playbook playbooks/main.yml --extra-vars "@$${config}"
         done
 
 volumes:

--- a/inventory.ini
+++ b/inventory.ini
@@ -1,2 +1,0 @@
-[minio]
-localhost ansible_connection=local

--- a/roles/minio-init/defaults/main.yml
+++ b/roles/minio-init/defaults/main.yml
@@ -13,6 +13,7 @@ minio_buckets: []
   #   state: present  # or absent
   #   versioning: enable  # or suspend
   #   lifecycle_file: "path/to/lifecycle.json"
+  #   expire_days: 10
 
 # Users configuration
 minio_users: []

--- a/roles/minio-init/tasks/buckets.yml
+++ b/roles/minio-init/tasks/buckets.yml
@@ -32,8 +32,35 @@
       register: version_result
       changed_when: version_result.rc == 0
 
+    # https://min.io/docs/minio/linux/reference/minio-mc/mc-ilm-rule-rm.html
+    - name: Remove all ILM rules
+      ansible.builtin.command: >
+        mc ilm rule rm myminio/{{ item.name }} --all --force
+      when:
+        - item.state | default('present') == 'present'
+        - item.expire_days is defined or item.lifecycle_file is defined
+      register: ilm_result
+      changed_when: ilm_result.rc == 0
+      failed_when:
+        - ilm_result.rc != 0
+        - '"does not exist" not in ilm_result.stderr'
+
+    # https://min.io/docs/minio/linux/reference/minio-mc/mc-ilm-rule-add.html
+    - name: Add expire days ILM rule
+      ansible.builtin.command: >
+        mc ilm rule add myminio/{{ item.name }} --expire-all-object-versions --expire-days {{ item.expire_days }}
+      when:
+        - item.state | default('present') == 'present'
+        - item.expire_days is defined
+      register: ilm_result
+      changed_when: ilm_result.rc == 0
+      failed_when:
+        - ilm_result.rc != 0
+        - '"already exists" not in ilm_result.stderr'
+
+    # This overrides the added ILM rule(s) above.
     # https://min.io/docs/minio/linux/reference/minio-mc/mc-ilm-rule-import.html
-    - name: Manage lifecycle rules
+    - name: Import ILM rule configuration
       when:
         - item.state | default('present') == 'present'
         - item.lifecycle_file is defined

--- a/tests/group_vars/all.yml
+++ b/tests/group_vars/all.yml
@@ -2,8 +2,11 @@
 minio_buckets:
   - name: "test-bucket"
     state: present
-    versioning: enable
     lifecycle_file: "/config/files/custom-lifecycle-rules.json"
+  - name: "test-bucket-2"
+    state: present
+    versioning: enable
+    expire_days: 10
 
 minio_users:
   - name: "testuser"


### PR DESCRIPTION
This allows us to set expire days via env vars
rather than only lifecycle rule files.